### PR TITLE
maturin 0.12.12

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "maturin" %}
-{% set version = "0.11.5" %}
+{% set version = "0.12.12" %}
 
 package:
   name: {{ name }}
@@ -7,18 +7,16 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 07074778b063a439fdfd5501bd1d1823a216ec5b657d3ecde78fd7f2c4782422
+  sha256: c7ace888bedc106ae37d86a1639aae8f034498c96940bf52dc2451b6fffac851
 
 build:
-  number: 1
-  skip: true  # [py27]
+  number: 0
+  skip: true  # [py<36]
   missing_dso_whitelist:   # [osx]
     - /usr/lib/libresolv.9.dylib  # [osx]
 
 requirements:
   build:
-    - python                                 # [build_platform != target_platform]
-    - cross-python_{{ target_platform }}     # [build_platform != target_platform]
     - {{ compiler('c') }}              # [unix]
     - {{ compiler('m2w64_c') }}        # [win]
     # seems to work with defaults from conda-forge-pinning (at the moment)
@@ -27,24 +25,31 @@ requirements:
     - rust >=1.54  # [osx]
   host:
     - pip
-    - python
-    - toml
+    - python <3.11
+    - tomli >=1.1.0
+    # Use setuptools <60 to fix ValueError: invalid pyproject.toml config: `project`
+    - setuptools >=53.0.0,<60
+    - wheel >=0.36.2
   run:
-    - python
-    - toml >=0.10.2,<0.11
+    - python <3.11
+    - tomli >=1.1.0
 
 test:
+  requires:
+    - pip
   commands:
+    - pip check
     - maturin --help
 
 about:
-  home: https://github.com/PyO3/maturin
+  home: https://maturin.rs/
   license: MIT
   license_family: MIT
   license_file: license-mit
   summary: >-
     Build and publish crates with pyo3, rust-cpython and cffi bindings as well as rust binaries as python packages
-
+  dev_url: https://github.com/PyO3/maturin
+  doc_url: https://maturin.rs/
 extra:
   recipe-maintainers:
     - apcamargo

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 0
-  skip: true  # [py<36]
+  skip: true  # [py<36 or win32 or ppc64le or s390x or aarch64]
   missing_dso_whitelist:   # [osx]
     - /usr/lib/libresolv.9.dylib  # [osx]
 
@@ -25,7 +25,7 @@ requirements:
     - rust >=1.54  # [osx]
   host:
     - pip
-    - python <3.11
+    - python
     - tomli >=1.1.0
     # Use setuptools <60 to fix ValueError: invalid pyproject.toml config: `project`
     - setuptools >=53.0.0,<60


### PR DESCRIPTION
It's a dependency for pywinpty -> terminado -> jupyterlab_server

Changelog: https://maturin.rs/changelog.html
License: https://github.com/PyO3/maturin/blob/v0.12.12/license-mit
Requirements: 
- https://github.com/PyO3/maturin/blob/v0.12.12/pyproject.toml
- https://github.com/PyO3/maturin/blob/v0.12.12/setup.py

Actions:
1. Skip py<36, win32, ppc64le, s390x, and aarch64
2. Add missing and update dependencies
3. Add pip check
4. Update home url
5. Add dev and doc urls