### PR TITLE
[PKG-2064] maturin 0.14.17

### DIFF
--- a/recipe/bld-win.bat
+++ b/recipe/bld-win.bat
@@ -19,4 +19,4 @@ REM set UTF-8 mode by default
 chcp 65001
 set PYTHONUTF8=1
 set PYTHONIOENCODING="UTF-8"
-%PYTHON% -m pip install . --no-deps --ignore-installed -vv
+%PYTHON% -m pip install . --no-deps --no-build-isolation --ignore-installed -vv

--- a/recipe/build-unix.sh
+++ b/recipe/build-unix.sh
@@ -11,4 +11,4 @@ export RUSTUP_HOME=${CARGO_HOME}/rustup
 rustc --version
 
 # Install wheel manually
-$PYTHON -m pip install . --no-deps --ignore-installed -vv
+$PYTHON -m pip install . --no-deps --no-build-isolation --ignore-installed -vv

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -58,7 +58,7 @@ outputs:
         - python                       # [win]
         - setuptools                   # [win]
         - setuptools-rust 1.5.2        # [win]
-        - wheels                       # [win]
+        - wheel                        # [win]
         - tomli                        # [win or py<311]
       run:                             # [win]
         - python                       # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,10 +33,10 @@ outputs:
         - setuptools
         - setuptools-rust 1.5.2
         - wheel
-        - tomli
+        - tomli                       # [py<311]
       run:
         - python
-        - tomli >=1.1.0
+        - tomli >=1.1.0               # [py<311]
     test:
       imports:
         - maturin
@@ -48,32 +48,34 @@ outputs:
         - maturin build --help
         - pip check
 
-  - name: {{ name }}-gnu               # [win]
-    script: bld-win.bat                # [win]
-    requirements:                      # [win]
-      build:                           # [win]
-        - {{ compiler('m2w64_c') }}    # [win]
-        - rust-gnu_win-64              # [win]
-      host:                            # [win]
-        - pip                          # [win]
-        - python                       # [win]
-        - setuptools                   # [win]
-        - setuptools-rust 1.5.2        # [win]
-        - wheel                        # [win]
-        - tomli                        # [win]
-      run:                             # [win]
-        - python                       # [win]
-        - tomli >=1.1.0                # [win]
-    test:                              # [win]
-      imports:                         # [win]
-        - maturin                      # [win]
-      requires:                        # [win]
-        - pip                          # [win]
-      commands:                        # [win]
-        - maturin -V                   # [win]
-        - maturin --help               # [win]
-        - maturin build --help         # [win]
-        - pip check                    # [win]
+  - name: {{ name }}-gnu
+    script: bld-win.bat
+    build:
+      skip: true  # [not win]
+    requirements:
+      build:
+        - {{ compiler('m2w64_c') }}
+        - rust-gnu_win-64
+      host:
+        - pip
+        - python
+        - setuptools
+        - setuptools-rust 1.5.2
+        - wheel
+        - tomli                        # [py<311]
+      run:
+        - python
+        - tomli >=1.1.0                # [py<311]
+    test:
+      imports:
+        - maturin
+      requires:
+        - pip
+      commands:
+        - maturin -V
+        - maturin --help
+        - maturin build --help
+        - pip check
 
 about:
   home: https://www.maturin.rs/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "maturin" %}
-{% set version = "0.13.7" %}
+{% set version = "0.14.17" %}
 
 package:
   name: {{ name }}-suite
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: c0a77aa0c57f945649ca711c806203a1b6888ad49c2b8b85196ffdcf0421db77
+  sha256: fb4e3311e8ce707843235fbe8748a05a3ae166c3efd6d2aa335b53dfc2bd3b88
 
 build:
   number: 0
@@ -31,12 +31,12 @@ outputs:
         - pip
         - python
         - setuptools
-        - setuptools-rust >=1.4.0
-        - wheel >=0.36.2
-        - tomli >=1.1.0
+        - setuptools-rust 1.5.2
+        - wheel
+        - tomli                      # [py<311]
       run:
         - python
-        - tomli >=1.1.0
+        - tomli >=1.1.0              # [py<311]
     test:
       imports:
         - maturin
@@ -57,12 +57,12 @@ outputs:
         - pip                          # [win]
         - python                       # [win]
         - setuptools                   # [win]
-        - setuptools-rust >=1.4.0      # [win]
-        - wheel >=0.36.2               # [win]
-        - tomli >=1.1.0                # [win]
+        - setuptools-rust 1.5.2        # [win]
+        - wheels                       # [win]
+        - tomli                        # [win or py<311]
       run:                             # [win]
         - python                       # [win]
-        - tomli >=1.1.0                # [win]
+        - tomli >=1.1.0                # [win or py<311]
     test:                              # [win]
       imports:                         # [win]
         - maturin                      # [win]
@@ -75,7 +75,7 @@ outputs:
         - pip check                    # [win]
 
 about:
-  home: https://maturin.rs/
+  home: https://www.maturin.rs/
   license: MIT OR Apache-2.0
   license_family: MIT
   license_file: license-mit
@@ -85,8 +85,7 @@ about:
     This project is meant as a zero configuration replacement for setuptools-rust and milksnake.
     It supports building wheels for python 3.5+ on windows, linux, mac and freebsd, can upload them to pypi and has basic pypy support.
   dev_url: https://github.com/PyO3/maturin
-  doc_url: https://maturin.rs/
-  doc_source_url: https://github.com/PyO3/maturin/tree/v{{ version }}/guide/src
+  doc_url: https://www.maturin.rs/
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,10 +33,10 @@ outputs:
         - setuptools
         - setuptools-rust 1.5.2
         - wheel
-        - tomli                      # [py<311]
+        - tomli  # [py<311]
       run:
         - python
-        - tomli >=1.1.0              # [py<311]
+        - tomli >=1.1.0  # [py<311]
     test:
       imports:
         - maturin

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,6 +47,7 @@ outputs:
         - maturin --help
         - maturin build --help
         - pip check
+
   - name: {{ name }}-gnu               # [win]
     script: bld-win.bat                # [win]
     requirements:                      # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,10 +33,10 @@ outputs:
         - setuptools
         - setuptools-rust 1.5.2
         - wheel
-        - tomli  # [py<311]
+        - tomli
       run:
         - python
-        - tomli >=1.1.0  # [py<311]
+        - tomli >=1.1.0
     test:
       imports:
         - maturin
@@ -60,10 +60,10 @@ outputs:
         - setuptools                   # [win]
         - setuptools-rust 1.5.2        # [win]
         - wheel                        # [win]
-        - tomli                        # [win or py<311]
+        - tomli                        # [win]
       run:                             # [win]
         - python                       # [win]
-        - tomli >=1.1.0                # [win or py<311]
+        - tomli >=1.1.0                # [win]
     test:                              # [win]
       imports:                         # [win]
         - maturin                      # [win]


### PR DESCRIPTION
Changelog: https://github.com/PyO3/maturin/releases
Requirements: 
- https://github.com/PyO3/maturin/blob/v0.14.17/setup.py
- https://github.com/PyO3/maturin/blob/v0.14.17/pyproject.toml

Notes:
- **lazrs-python 0.5.0** relies on `maturin >=14,<15`, see https://github.com/laz-rs/laz-rs-python/blob/0.5.0/pyproject.toml#L11 that's why we do not build the latest version of maturin