### PR TITLE
Update to 1.3.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "maturin" %}
-{% set version = "1.3.0" %}
+{% set version = "1.3.1" %}
 
 package:
   name: {{ name }}-suite
@@ -7,13 +7,18 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: f6c69bc7ae147a5effd55587447b35cab1ceb726ba244d08698bc7518b8688ac
+  sha256: efa194e99ae5fff185263d8244acacb12ae256ea73aba62c9446f6075ffc7ac1
+  patches:  # [s390x]
+    # ring adds big endian support from 0.17 only
+    - patches/0001-ring-0.17.3-for-s390x.patch # [s390x]
 
 build:
   number: 0
-  # ring (dependency loaded via cargo) is not supported on s390x yet
-  # https://github.com/briansmith/ring/issues/1511
-  skip: True  # [py<37 or s390x]
+  skip: True  # [py<37]
+
+requirements: # [s390x]
+  build:      # [s390x]
+    - patch   # [s390x]
 
 
 outputs:
@@ -33,7 +38,7 @@ outputs:
         - setuptools
         - setuptools-rust
         - wheel
-        - tomli                 # [py<311]
+        - tomli >=1.1.0               # [py<311]
       run:
         - python
         - tomli >=1.1.0               # [py<311]
@@ -62,7 +67,7 @@ outputs:
         - setuptools
         - setuptools-rust
         - wheel
-        - tomli                       # [py<311]
+        - tomli >=1.1.0                # [py<311]
       run:
         - python
         - tomli >=1.1.0                # [py<311]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,8 +25,9 @@ outputs:
   - name: {{ name }}
     script: bld-win.bat                  # [win]
     script: build-unix.sh                # [not win]
-    missing_dso_whitelist:   # [osx]
+    missing_dso_whitelist:   # [osx or s390x]
       - /usr/lib/libresolv.9.dylib  # [osx]
+    - '$RPATH/ld64.so.1'  # [s390x]
     requirements:
       build:
         - {{ compiler('c') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,9 +25,9 @@ outputs:
   - name: {{ name }}
     script: bld-win.bat                  # [win]
     script: build-unix.sh                # [not win]
-    missing_dso_whitelist:   # [osx or s390x]
-      - /usr/lib/libresolv.9.dylib  # [osx]
-      - '$RPATH/ld64.so.1'  # [s390x]
+    build:
+      missing_dso_whitelist:
+        - '$RPATH/ld64.so.1'  # [s390x]
     requirements:
       build:
         - {{ compiler('c') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,7 @@ outputs:
     script: build-unix.sh                # [not win]
     missing_dso_whitelist:   # [osx or s390x]
       - /usr/lib/libresolv.9.dylib  # [osx]
-    - '$RPATH/ld64.so.1'  # [s390x]
+      - '$RPATH/ld64.so.1'  # [s390x]
     requirements:
       build:
         - {{ compiler('c') }}

--- a/recipe/patches/0001-ring-0.17.3-for-s390x.patch
+++ b/recipe/patches/0001-ring-0.17.3-for-s390x.patch
@@ -1,0 +1,286 @@
+From cd965d63d60464aca66f99eaa1d16b9fee6adfb2 Mon Sep 17 00:00:00 2001
+From: messense <messense@icloud.com>
+Date: Thu, 26 Oct 2023 05:23:58 +0000
+Subject: [PATCH] Upgrade ring to 0.17
+
+---
+ .github/workflows/release.yml |  52 +++-----------
+ Cargo.lock                    | 132 +++++++---------------------------
+ Cargo.toml                    |   6 +-
+ 3 files changed, 38 insertions(+), 152 deletions(-)
+
+diff --git a/Cargo.lock b/Cargo.lock
+index 9d94d7e3..fb66e5ea 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -126,12 +126,6 @@ dependencies = [
+  "serde",
+ ]
+ 
+-[[package]]
+-name = "bumpalo"
+-version = "3.13.0"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
+-
+ [[package]]
+ name = "byteorder"
+ version = "1.4.3"
+@@ -246,9 +240,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "cargo-zigbuild"
+-version = "0.17.3"
++version = "0.17.4"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "2307bb523befb01f7e8cf299c2219439339316964c3a4e95e29bd1c7831fae89"
++checksum = "e0602b6ad0679c9e6fcae875bcdb0440976b86128fb4e3ae4e112135d85f5e11"
+ dependencies = [
+  "anyhow",
+  "cargo-options",
+@@ -282,9 +276,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "cbindgen"
+-version = "0.25.0"
++version = "0.26.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "faeaa693e5a727975a79211b8f35c0cb09b031fdb6eaa4a788bc6713d01488ca"
++checksum = "da6bc11b07529f16944307272d5bd9b22530bc7d05751717c9d416586cedab49"
+ dependencies = [
+  "heck",
+  "indexmap",
+@@ -576,12 +570,13 @@ checksum = "c2e66c9d817f1720209181c316d28635c050fa304f9c79e47a520882661b7308"
+ 
+ [[package]]
+ name = "dialoguer"
+-version = "0.10.4"
++version = "0.11.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "59c6f2989294b9a498d3ad5491a79c6deb604617378e1cdc4bfc1c1361fe2f87"
++checksum = "658bce805d770f407bc62102fca7c2c64ceef2fbcb2b8bd19d2765ce093980de"
+ dependencies = [
+  "console",
+  "shell-words",
++ "thiserror",
+  "zeroize",
+ ]
+ 
+@@ -963,15 +958,6 @@ version = "1.0.9"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
+ 
+-[[package]]
+-name = "js-sys"
+-version = "0.3.64"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
+-dependencies = [
+- "wasm-bindgen",
+-]
+-
+ [[package]]
+ name = "keyring"
+ version = "2.0.5"
+@@ -1672,17 +1658,16 @@ dependencies = [
+ 
+ [[package]]
+ name = "ring"
+-version = "0.16.20"
++version = "0.17.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
++checksum = "9babe80d5c16becf6594aa32ad2be8fe08498e7ae60b77de8df700e67f191d7e"
+ dependencies = [
+  "cc",
++ "getrandom",
+  "libc",
+- "once_cell",
+  "spin",
+  "untrusted",
+- "web-sys",
+- "winapi",
++ "windows-sys 0.48.0",
+ ]
+ 
+ [[package]]
+@@ -1710,9 +1695,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "rustls"
+-version = "0.21.2"
++version = "0.21.8"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "e32ca28af694bc1bbf399c33a516dbdf1c90090b8ab23c2bc24f834aa2247f5f"
++checksum = "446e14c5cda4f3f30fe71863c34ec70f5ac79d6087097ad0bb433e1be5edf04c"
+ dependencies = [
+  "log",
+  "ring",
+@@ -1731,9 +1716,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "rustls-webpki"
+-version = "0.100.2"
++version = "0.101.7"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "e98ff011474fa39949b7e5c0428f9b4937eda7da7848bbb947786b7be0b27dab"
++checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+ dependencies = [
+  "ring",
+  "untrusted",
+@@ -1797,9 +1782,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "sct"
+-version = "0.7.0"
++version = "0.7.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
++checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+ dependencies = [
+  "ring",
+  "untrusted",
+@@ -1977,9 +1962,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "spin"
+-version = "0.5.2"
++version = "0.9.8"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
++checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+ 
+ [[package]]
+ name = "stacker"
+@@ -2356,15 +2341,15 @@ checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
+ 
+ [[package]]
+ name = "untrusted"
+-version = "0.7.1"
++version = "0.9.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
++checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+ 
+ [[package]]
+ name = "ureq"
+-version = "2.7.1"
++version = "2.8.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "0b11c96ac7ee530603dcdf68ed1557050f374ce55a5a07193ebf8cbc9f8927e9"
++checksum = "f5ccd538d4a604753ebc2f17cd9946e89b77bf87f6a8e2309667c6f2e87855e3"
+ dependencies = [
+  "base64 0.21.2",
+  "flate2",
+@@ -2457,78 +2442,11 @@ version = "0.11.0+wasi-snapshot-preview1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+ 
+-[[package]]
+-name = "wasm-bindgen"
+-version = "0.2.87"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
+-dependencies = [
+- "cfg-if",
+- "wasm-bindgen-macro",
+-]
+-
+-[[package]]
+-name = "wasm-bindgen-backend"
+-version = "0.2.87"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
+-dependencies = [
+- "bumpalo",
+- "log",
+- "once_cell",
+- "proc-macro2",
+- "quote",
+- "syn 2.0.29",
+- "wasm-bindgen-shared",
+-]
+-
+-[[package]]
+-name = "wasm-bindgen-macro"
+-version = "0.2.87"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
+-dependencies = [
+- "quote",
+- "wasm-bindgen-macro-support",
+-]
+-
+-[[package]]
+-name = "wasm-bindgen-macro-support"
+-version = "0.2.87"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
+-dependencies = [
+- "proc-macro2",
+- "quote",
+- "syn 2.0.29",
+- "wasm-bindgen-backend",
+- "wasm-bindgen-shared",
+-]
+-
+-[[package]]
+-name = "wasm-bindgen-shared"
+-version = "0.2.87"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
+-
+-[[package]]
+-name = "web-sys"
+-version = "0.3.64"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
+-dependencies = [
+- "js-sys",
+- "wasm-bindgen",
+-]
+-
+ [[package]]
+ name = "webpki-roots"
+-version = "0.23.1"
++version = "0.25.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "b03058f88386e5ff5310d9111d53f48b17d732b401aeb83a8d5190f2ac459338"
+-dependencies = [
+- "rustls-webpki",
+-]
++checksum = "14247bb57be4f377dfb94c72830b8ce8fc6beac03cf4bf7b9732eadd414123fc"
+ 
+ [[package]]
+ name = "which"
+diff --git a/Cargo.toml b/Cargo.toml
+index 152c555e..6bac735f 100644
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -41,7 +41,7 @@ glob = "0.3.0"
+ cargo-config2 = "0.1.9"
+ cargo_metadata = "0.18.0"
+ cargo-options = "0.6.0"
+-cbindgen = { version = "0.25.0", default-features = false }
++cbindgen = { version = "0.26.0", default-features = false }
+ flate2 = "1.0.18"
+ goblin = "0.7.1"
+ platform-info = "2.0.2"
+@@ -88,7 +88,7 @@ tracing = "0.1.36"
+ tracing-subscriber = { version = "0.3.15", features = ["env-filter"], optional = true }
+ 
+ # project scaffolding, maturin new/init/generate-ci
+-dialoguer = { version = "0.10.2", default-features = false, optional = true }
++dialoguer = { version = "0.11.0", default-features = false, optional = true }
+ console = { version = "0.15.4", optional = true }
+ minijinja = { version = "1.0.7", optional = true }
+ 
+@@ -99,7 +99,7 @@ dirs = { version = "5.0.0", optional = true }
+ multipart = { version = "0.18.0", features = ["client"], default-features = false, optional = true }
+ ureq = { version = "2.7.0", features = ["gzip", "json", "socks-proxy"], default-features = false, optional = true }
+ native-tls = { version = "0.2.8", optional = true }
+-rustls = { version = "0.21.2", optional = true }
++rustls = { version = "0.21.8", optional = true }
+ rustls-pemfile = { version = "1.0.1", optional = true }
+ keyring = { version = "2.0.0", default-features = false, features = ["linux-no-secret-service"], optional = true }
+ wild = { version = "2.1.0", optional = true }


### PR DESCRIPTION
Changes:
- Update to 1.3.1
- Backport ring dependency update for big endian support

https://github.com/PyO3/maturin/tree/v1.3.1
https://github.com/PyO3/maturin/pull/1819