### PR TITLE
maturin 1.5.1 build1

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 3dd834ece80edb866af18cbd4635e0ecac40139c726428d5f1849ae154b26dca
 
 build:
-  number: 0
+  number: 1
   skip: True  # [py<37]
 
 outputs:


### PR DESCRIPTION
maturin 1.5.1 build1

**Destination channel:** Defaults

### Links

- [PKG-6661]
- dev_url:        https://github.com/PyO3/maturin/tree/v1.5.1

### Explanation of changes:

- Rebuild to get missing `win-64` artifacts.


[PKG-6661]: https://anaconda.atlassian.net/browse/PKG-6661?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ