### PR TITLE
PKG-9364: maturin 1.9.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,13 @@
 {% set name = "maturin" %}
-{% set version = "1.8.6" %}
+{% set version = "1.9.3" %}
 
 package:
   name: {{ name }}-suite
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 0e0dc2e0bfaa2e1bd238e0236cf8a2b7e2250ccaa29c1aa8d0e61fa664b0289d
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 267ac8d0471d1ee2320b8b2ee36f400a32cd2492d7becbd0d976bd3503c2f69b
 
 build:
   number: 0
@@ -17,24 +17,23 @@ outputs:
   - name: {{ name }}
     script: bld-win.bat                  # [win]
     script: build-unix.sh                # [not win]
-    build:
-      missing_dso_whitelist:
-        - '$RPATH/ld64.so.1'  # [s390x]
     requirements:
       build:
+        - {{ stdlib('c') }}
         - {{ compiler('c') }}
         - {{ compiler('rust') }}     # [not win]
         - rust_win-64                # [win]
       host:
         - pip
         - python
-        - setuptools
+        - setuptools >=77.0.0
         - setuptools-rust >=1.11.0
-        - wheel
         - tomli >=1.1.0               # [py<311]
       run:
         - python
         - tomli >=1.1.0               # [py<311]
+      run_constrained:
+        - ziglang >=0.10.0,<0.13.0
     test:
       imports:
         - maturin
@@ -57,13 +56,14 @@ outputs:
       host:
         - pip
         - python
-        - setuptools
+        - setuptools >=77.0.0
         - setuptools-rust >=1.4.0
-        - wheel
         - tomli >=1.1.0                # [py<311]
       run:
         - python
         - tomli >=1.1.0                # [py<311]
+      run_constrained:
+        - ziglang >=0.10.0,<0.13.0
     test:
       imports:
         - maturin
@@ -76,7 +76,7 @@ outputs:
         - pip check
 
 about:
-  home: https://www.maturin.rs/
+  home: https://www.maturin.rs
   license: MIT OR Apache-2.0
   license_family: MIT
   license_file: license-mit
@@ -86,8 +86,12 @@ about:
     Build and publish crates with pyo3, cffi and uniffi bindings as well as rust binaries as python packages with minimal configuration. 
     It supports building wheels for python 3.8+ on Windows, Linux, macOS and FreeBSD, can upload them to pypi and has basic PyPy and GraalPy support.
   dev_url: https://github.com/PyO3/maturin
-  doc_url: https://www.maturin.rs/
+  doc_url: https://www.maturin.rs
 
 extra:
   recipe-maintainers:
     - apcamargo
+  skip-lints:
+    # not for m2w64_c compiler
+    - should_use_stdlib
+    - host_section_needs_exact_pinnings


### PR DESCRIPTION
maturin 1.9.3

**Destination channel:** defaults

### Links

- [PKG-9364](https://anaconda.atlassian.net/browse/PKG-9364) 
- [Upstream repository](https://github.com/PyO3/maturin/tree/v1.9.3)

### Explanation of changes:

- update new version


[PKG-9364]: https://anaconda.atlassian.net/browse/PKG-9364?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ