### PR TITLE
maturin 1.9.4 

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,6 @@
+c_compiler_version:      # [osx]
+  - 14                   # [osx]
+MACOSX_SDK_VERSION:      # [osx]
+  - 11.1                 # [osx]
+CONDA_BUILD_SYSROOT:     # [osx]
+  - /Library/Developer/CommandLineTools/SDKs/MacOSX11.1.sdk  # [osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "maturin" %}
-{% set version = "1.9.3" %}
+{% set version = "1.9.4" %}
 
 package:
   name: {{ name }}-suite
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 267ac8d0471d1ee2320b8b2ee36f400a32cd2492d7becbd0d976bd3503c2f69b
+  sha256: 235163a0c99bc6f380fb8786c04fd14dcf6cd622ff295ea3de525015e6ac40cf
 
 build:
   number: 0
@@ -92,6 +92,4 @@ extra:
   recipe-maintainers:
     - apcamargo
   skip-lints:
-    # not for m2w64_c compiler
-    - should_use_stdlib
     - host_section_needs_exact_pinnings


### PR DESCRIPTION
maturin 1.9.4 

**Destination channel:** default

### Links

- [PKG-9593]
- dev_url:        https://github.com/PyO3/maturin/tree/v1.9.4
- conda_forge:    https://github.com/conda-forge/maturin-feedstock
- pypi:           https://pypi.org/project/maturin/1.9.4
- pypi inspector: https://inspector.pypi.io/project/maturin/1.9.4

### Explanation of changes:

- new version number
- pinned Clang and OSX SDK due to:
```Could not solve for environment specs
The following packages are incompatible
├─ clang_osx-arm64 =17 * is requested and can be installed;
└─ rust_osx-arm64 =1.87.0 * is not installable because it requires
   └─ clang_osx-arm64 =14 *, which conflicts with any installable versions previously reported.
ERROR: Failed to get package records, max retries exceeded.
```

[PKG-9593]: https://anaconda.atlassian.net/browse/PKG-9593?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ